### PR TITLE
Modify/fix gs saving option

### DIFF
--- a/R/run_pipeline.R
+++ b/R/run_pipeline.R
@@ -71,7 +71,7 @@ run_pipeline <- function(data_path, view_config = TRUE, gating_output = NULL) {
                                   mustWork = TRUE),
                       output_file = file.path(data_path, paste0(experiment_name, "_gating.html")))
   } else if (gating_output == "set") {
-    return(gs)
+    flowWorkspace::save_gs(gs, path = "gs")
   }
 
   data_cs <- flowWorkspace::gs_pop_get_data(gs, y = "singlets")


### PR DESCRIPTION
The implementation of exporting the GatingSet in ca75c207b8c15a138d5e6e4db800a03b77f4afbd does not return the `data_dt` object _with the measurement values_, but only the `gs` (as `data_dt`) when setting `gating_output == "set"`.

This happens since in the `run_pipeline.R` there are 2 `return()` calls. To fix this, we can try returning multiple objects by using alternative functions (since `return()` only returns a single object).

However, I think a better alternative is just to directly export/save the `gs` in the output folder,  similar to what would happen with the .html report if `gating_output == "report"` is set by the user. This has also the advantage of not keeping a lot of different objects in the environment and the user that chose the "set" option in the beginning  can keep the `gs` (as he/she would keep the gating template or gating report in the other case) for future downstream analysis/plotting.

An example output folder when `gating_output == "set"` is chosen.

![image](https://user-images.githubusercontent.com/63583995/132323552-fde1ac2e-f3fa-4aa5-8edd-75b3d0312e8d.png)
